### PR TITLE
Tests for preprocessing without hard-coded paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ venv.bak/
 
 # codecov
 .coverage
+
+# VS Code
+settings.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: develop test clean_python_cache all install
+.PHONY: develop test test_coverage all install
 
 all: develop
 

--- a/src/rbp/preprocessing/bed2cons.py
+++ b/src/rbp/preprocessing/bed2cons.py
@@ -27,7 +27,7 @@ def get_conservation(intervals: Union[str, pd.DataFrame], reference: str):
         intervals_df = pd.read_csv(
             intervals, sep="\t", names=field_name.keys(), dtype=field_name,
         )
-    elif isinstance(tst, pd.core.frame.DataFrame) == True:
+    elif isinstance(intervals, pd.core.frame.DataFrame):
         pass
     else:
         raise TypeError("Input must be BED file or Pandas DataFrame")

--- a/src/rbp/preprocessing/bed2fa.py
+++ b/src/rbp/preprocessing/bed2fa.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from pybedtools import BedTool
-import io
 from typing import Union
 
 
@@ -23,7 +22,7 @@ def get_fasta(intervals: Union[str, pd.DataFrame], reference: str, tab: bool = T
     if isinstance(intervals, str):
         assert intervals.endswith('bed'), 'required BED-6 file as input file'
         bed_obj = BedTool(intervals)  # creates bedtool obj
-    elif isinstance(intervals, pd.core.frame.DataFrame) == True:
+    elif isinstance(intervals, pd.core.frame.DataFrame):
         bed_obj = BedTool.from_dataframe(intervals)  # creates bedtool obj
     else:
         raise TypeError("Input must be BED file or Pandas DataFrame")

--- a/tests/encoding/test_dot_matrix.py
+++ b/tests/encoding/test_dot_matrix.py
@@ -1,4 +1,3 @@
-import pytest
 import pandas as pd
 import numpy as np
 from rbp.encoding import dot_matrix

--- a/tests/preprocessing/test_bed2fa.py
+++ b/tests/preprocessing/test_bed2fa.py
@@ -1,4 +1,5 @@
 import io
+import pytest
 import pandas as pd
 from pathlib import Path
 from rbp.preprocessing import bed2fa
@@ -18,6 +19,10 @@ def test_bed2fa_from_file():
     actual_output = bed2fa.get_fasta(str(bed_path), str(reference_path))
     assert actual_output.sequence.tolist() == expeted_output
 
+    actual_output2 = bed2fa.get_fasta(str(bed_path), str(reference_path), tab=False)
+    expeted_output2 = ">int1::test:10-20(+)\nAACTTCCAAG"
+    assert actual_output2[:31] == expeted_output2
+
 
 def test_from_dataframe():
     reference_path = test_data_dir / 'test_reference.fa'
@@ -35,3 +40,8 @@ def test_from_dataframe():
 
     actual_output = bed2fa.get_fasta(intervals, str(reference_path))
     assert actual_output.sequence.tolist() == expeted_output
+
+
+def test_fails_on_wrong_type():
+    with pytest.raises(TypeError):
+        bed2fa.get_fasta(float(1), pd.DataFrame())

--- a/tests/preprocessing/test_bed2fa.py
+++ b/tests/preprocessing/test_bed2fa.py
@@ -1,26 +1,28 @@
-import os
-import pandas as pd
 import io
+import pandas as pd
+from pathlib import Path
 from rbp.preprocessing import bed2fa
+
+test_data_dir = Path(__file__).parents[0] / '../data'
 
 
 def test_bed2fa_from_file():
-    bed_path = "tests/data/test_bed.bed"
-    reference_path = "tests/data/test_reference.fa"
+    bed_path = test_data_dir / "test_bed.bed"
+    reference_path = test_data_dir / "test_reference.fa"
 
-    assert os.path.exists(bed_path)
-    assert os.path.exists(reference_path)
+    assert bed_path.exists()
+    assert reference_path.exists()
 
     expeted_output = ["AACTTCCAAG", "TTTGTCCTTTCTAGTTCTGT",
                       "GAGCTTTTGT", "TTTGTCCTTTCTAGTTCTGTGCATAGGTGCTGCCT", "ACTT"]
-    actual_output = bed2fa.get_fasta(bed_path, reference_path)
+    actual_output = bed2fa.get_fasta(str(bed_path), str(reference_path))
     assert actual_output.sequence.tolist() == expeted_output
 
 
 def test_from_dataframe():
-    reference_path = "tests/data/test_reference.fa"
+    reference_path = test_data_dir / "test_reference.fa"
 
-    assert os.path.exists(reference_path)
+    assert reference_path.exists()
     bed_string = io.StringIO(
         "test\t10\t20\tint1\t.\t+\ntest\t30\t50\tint2\t.\t+\ntest\t25\t35\tint3\t.\t+\ntest\t30\t65\tint4\t.\t+\ntest\t11\t15\tint5\t.\t+\n")
     intervals = pd.read_csv(bed_string, sep="\t")
@@ -31,5 +33,5 @@ def test_from_dataframe():
         "ACTT"
     ]
 
-    actual_output = bed2fa.get_fasta(intervals, reference_path)
+    actual_output = bed2fa.get_fasta(intervals, str(reference_path))
     assert actual_output.sequence.tolist() == expeted_output

--- a/tests/preprocessing/test_bed2fa.py
+++ b/tests/preprocessing/test_bed2fa.py
@@ -3,12 +3,12 @@ import pandas as pd
 from pathlib import Path
 from rbp.preprocessing import bed2fa
 
-test_data_dir = Path(__file__).parents[0] / '../data'
+test_data_dir = Path(__file__).parents[0] / '..' / 'data'
 
 
 def test_bed2fa_from_file():
-    bed_path = test_data_dir / "test_bed.bed"
-    reference_path = test_data_dir / "test_reference.fa"
+    bed_path = test_data_dir / 'test_bed.bed'
+    reference_path = test_data_dir / 'test_reference.fa'
 
     assert bed_path.exists()
     assert reference_path.exists()
@@ -20,7 +20,7 @@ def test_bed2fa_from_file():
 
 
 def test_from_dataframe():
-    reference_path = test_data_dir / "test_reference.fa"
+    reference_path = test_data_dir / 'test_reference.fa'
 
     assert reference_path.exists()
     bed_string = io.StringIO(

--- a/tests/random/test_random_intervals.py
+++ b/tests/random/test_random_intervals.py
@@ -1,4 +1,3 @@
-import pytest
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import io


### PR DESCRIPTION
The primary goal of this PR is to avoid using paths in 'test/preprocessing' tests (because pytest then fails if not run from exact location). 

I also added extra tests, deleted unnecessary imports and fix .PHONY in Makefile.
